### PR TITLE
Enable to use F() macro with play() function

### DIFF
--- a/MmlMusic.cpp
+++ b/MmlMusic.cpp
@@ -139,10 +139,10 @@ void MmlMusic::play(const char* mml)
 	playMML(mml);
 }
 
-void MmlMusic::play_P(const char* mml)
+void MmlMusic::play(const __FlashStringHelper* mml)
 {
 	_fUseFlash=true;
-	playMML(mml);
+	playMML((const char* )mml);
 }
 
 void MmlMusic::stop()

--- a/MmlMusic.h
+++ b/MmlMusic.h
@@ -81,6 +81,10 @@ public:
      */
     void play(const char* mml);
     void play(const __FlashStringHelper* mml);
+    void play_P(const __FlashStringHelper* mml) /* for backward compatibility */
+    {
+		play(mml);
+	}
 
     /** Stop a currently playing sequence */
     void stop();

--- a/MmlMusic.h
+++ b/MmlMusic.h
@@ -80,7 +80,7 @@ public:
       * @param mml string of MML commands to be played
      */
     void play(const char* mml);
-    void play_P(const char* mml);
+    void play(const __FlashStringHelper* mml);
 
     /** Stop a currently playing sequence */
     void stop();


### PR DESCRIPTION
We now cannot compile
 music.play_P(F("CDEF");
due to compiler changes. Now we need const __FlashStringHelper** instead of const char **.

The changes in this request also changes the name play_P() to play() so that we can write as below;

  music.play("CDEF");
  music.play(F("CDEF"));
